### PR TITLE
Use the RX watermark interrupt pending bit for TSTC

### DIFF
--- a/drivers/serial/serial_hifive.c
+++ b/drivers/serial/serial_hifive.c
@@ -88,15 +88,11 @@ static void hifive_uart_putc(char ch)
 	writel(ch, &usart->txdata);
 }
 
-static int lastread;
-
 static int hifive_uart_getc(void)
 {
-
 	hifive_uart_t *usart = (hifive_uart_t *)HIFIVE_UART_BASE_ADDR;
 	int ch;
-	ch = lastread;
-        lastread = UART_RXFIFO_EMPTY;
+	ch = readl(&usart->rxdata);
 	while((ch & UART_RXFIFO_EMPTY) != 0)
 	{
 		ch = readl(&usart->rxdata);
@@ -107,9 +103,7 @@ static int hifive_uart_getc(void)
 static int hifive_uart_tstc(void)
 {
 	hifive_uart_t *usart = (hifive_uart_t *)HIFIVE_UART_BASE_ADDR;
-        if (lastread & UART_RXFIFO_EMPTY)
-                lastread = readl(&usart->rxdata);
-        return !(lastread & UART_RXFIFO_EMPTY);
+	return (readl(&usart->ip) & UART_IP_RXWM);
 }
 
 static struct serial_device hifive_uart_drv = {


### PR DESCRIPTION
This seems to fix a problem where tstc/getc doesn't
seem to work with kermit/xmodem/etc

https://github.com/sifive/sifive-blocks/blob/master/src/main/scala/devices/uart/UART.scala
may or may not be informative.